### PR TITLE
Trying to improve odict performance

### DIFF
--- a/babel/util.py
+++ b/babel/util.py
@@ -172,8 +172,9 @@ class odict(dict):
         self._keys.remove(key)
 
     def __setitem__(self, key, item):
+        new_key = key not in self
         dict.__setitem__(self, key, item)
-        if key not in self._keys:
+        if new_key:
             self._keys.append(key)
 
     def __iter__(self):


### PR DESCRIPTION
Odict __setitem__ method is linearly searching if item is present in keys list, which significantly reduces performance on big dict