### PR TITLE
Add __copy__ and __deepcopy__ to LazyProxy.

### DIFF
--- a/babel/support.py
+++ b/babel/support.py
@@ -263,6 +263,23 @@ class LazyProxy(object):
     def __setitem__(self, key, value):
         self.value[key] = value
 
+    def __copy__(self):
+        return LazyProxy(
+            self._func,
+            enable_cache=self._is_cache_enabled,
+            *self._args,
+            **self._kwargs
+        )
+
+    def __deepcopy__(self, memo):
+        from copy import deepcopy
+        return LazyProxy(
+            deepcopy(self._func, memo),
+            enable_cache=deepcopy(self._is_cache_enabled, memo),
+            *deepcopy(self._args, memo),
+            **deepcopy(self._kwargs, memo)
+        )
+
 
 class NullTranslations(gettext.NullTranslations, object):
 

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -243,6 +243,33 @@ class LazyProxyTestCase(unittest.TestCase):
         self.assertEqual(1, proxy.value)
         self.assertEqual(2, proxy.value)
 
+    def test_can_copy_proxy(self):
+        from copy import copy
+
+        numbers = [1,2]
+        def first(xs):
+            return xs[0]
+
+        proxy = support.LazyProxy(first, numbers)
+        proxy_copy = copy(proxy)
+
+        numbers.pop(0)
+        self.assertEqual(2, proxy.value)
+        self.assertEqual(2, proxy_copy.value)
+
+    def test_can_deepcopy_proxy(self):
+        from copy import deepcopy
+        numbers = [1,2]
+        def first(xs):
+            return xs[0]
+
+        proxy = support.LazyProxy(first, numbers)
+        proxy_deepcopy = deepcopy(proxy)
+
+        numbers.pop(0)
+        self.assertEqual(2, proxy.value)
+        self.assertEqual(1, proxy_deepcopy.value)
+
 
 def test_format_date():
     fmt = support.Format('en_US')


### PR DESCRIPTION
When copy.copy or copy.deepcopy is used to copy LazyProxy, __init__ is never called and self._value is never set to None. Accessing it in self.value (which is used in __getattr__) triggers another call to __getattr__, resulting in endless recursion.