### PR TITLE
Fix of losses of significant zeros in DateTimeFormat.format_frac_seconds()

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -1020,8 +1020,7 @@ class DateTimeFormat(object):
         return get_period_names(locale=self.locale)[period]
 
     def format_frac_seconds(self, num):
-        value = str(self.value.microsecond)
-        return self.format(round(float('.%s' % value), num) * 10**num, num)
+        return self.format(self.value.microsecond // 10**(6-num), num)
 
     def format_milliseconds_in_day(self, num):
         msecs = self.value.microsecond // 1000 + self.value.second * 1000 + \


### PR DESCRIPTION
Examples:

>>> dates.format_datetime(datetime.datetime(2014, 7, 4, 14, 16, 13, 1), 'HH:mm:ss.SSS')
u'14:16:13.100'
>>> dates.format_datetime(datetime.datetime(2014, 7, 4, 14, 16, 13, 100000), 'HH:mm:ss.SSS')
u'14:16:13.100'

And wrong rounding:

>>> dates.format_datetime(datetime.datetime(2014, 7, 4, 14, 16, 13, 999999), 'HH:mm:ss.SSS')
u'14:16:13.1000'

instead of u'14:16:14.000'

Wrong rounding error is difficult for fix because of every time unit (hours, seconds, frac seconds, ...) format separately. So we truncate microseconds instead of rounding ones. 

