### PR TITLE
Fix odict's pop method

### DIFF
--- a/babel/util.py
+++ b/babel/util.py
@@ -199,12 +199,15 @@ class odict(dict):
         return self._keys[:]
 
     def pop(self, key, default=missing):
-        if default is missing:
-            return dict.pop(self, key)
-        elif key not in self:
-            return default
-        self._keys.remove(key)
-        return dict.pop(self, key, default)
+        try:
+            value = dict.pop(self, key)
+            self._keys.remove(key)
+            return value
+        except KeyError as e:
+            if default == missing:
+                raise e
+            else:
+                return default
 
     def popitem(self, key):
         self._keys.remove(key)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,8 +11,6 @@
 # individuals. For the exact contribution history, see the revision
 # history and logs, available at http://babel.edgewall.org/log/.
 
-import doctest
-import unittest
 
 from babel import util
 
@@ -28,3 +26,16 @@ def test_pathmatch():
     assert not util.pathmatch('**.py', 'templates/index.html')
     assert util.pathmatch('**/templates/*.html', 'templates/index.html')
     assert not util.pathmatch('**/templates/*.html', 'templates/foo/bar.html')
+
+def test_odict_pop():
+    odict = util.odict()
+    odict[0] = 1
+    value = odict.pop(0)
+    assert 1 == value
+    assert [] == list(odict.items())
+    assert odict.pop(2, None) is None
+    try:
+        odict.pop(2)
+        assert False
+    except KeyError:
+        assert True


### PR DESCRIPTION
`odict.pop` method does not remove the key from the `_keys` attribute if
the default argument is not specified.