### PR TITLE
Allow multiple arguments for same keyword

### DIFF
--- a/babel/messages/frontend.py
+++ b/babel/messages/frontend.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from distutils import log
 from distutils.cmd import Command
 from distutils.errors import DistutilsOptionError, DistutilsSetupError
+from collections import defaultdict
 from locale import getpreferredencoding
 import logging
 from optparse import OptionParser
@@ -1227,22 +1228,22 @@ def parse_mapping(fileobj, filename=None):
 def parse_keywords(strings=[]):
     """Parse keywords specifications from the given list of strings.
 
-    >>> kw = parse_keywords(['_', 'dgettext:2', 'dngettext:2,3', 'pgettext:1c,2']).items()
+    >>> kw = parse_keywords(['_', '_:1,2', 'dgettext:2', 'dngettext:2,3', 'pgettext:1c,2']).items()
     >>> kw.sort()
     >>> for keyword, indices in kw:
     ...     print (keyword, indices)
-    ('_', None)
-    ('dgettext', (2,))
-    ('dngettext', (2, 3))
-    ('pgettext', ((1, 'c'), 2))
+    ('_', [None, (1, 2)])
+    ('dgettext', [(2,)])
+    ('dngettext', [(2, 3)])
+    ('pgettext', [((1, 'c'), 2)])
     """
-    keywords = {}
+    keywords = defaultdict(list)
     for string in strings:
         if ':' in string:
             funcname, indices = string.split(':')
         else:
             funcname, indices = string, None
-        if funcname not in keywords:
+        if funcname not in keywords or indices not in keywords[funcname]:
             if indices:
                 inds = []
                 for x in indices.split(','):
@@ -1251,7 +1252,7 @@ def parse_keywords(strings=[]):
                     else:
                         inds.append(int(x))
                 indices = tuple(inds)
-            keywords[funcname] = indices
+            keywords[funcname].append(indices)
     return keywords
 
 

--- a/babel/util.py
+++ b/babel/util.py
@@ -274,6 +274,26 @@ class FixedOffsetTimezone(tzinfo):
         return ZERO
 
 
+def len_recurse(l):
+    """Count length of given object recursively.
+
+    >>> len_recurse(None)
+    1
+    >>> len_recurse([1, 2])
+    2
+    >>> len_recurse([(1, 'c'), 2])
+    3
+    """
+    if not isinstance(l, (list, tuple)):
+        return 1
+    curr_len = 0
+    for elem in l:
+        if isinstance(elem, (list, tuple)):
+            curr_len += len_recurse(elem)
+        else:
+            curr_len += 1
+    return curr_len
+
 import pytz as _pytz
 from babel import localtime
 

--- a/tests/messages/test_frontend.py
+++ b/tests/messages/test_frontend.py
@@ -1089,11 +1089,11 @@ def test_parse_mapping():
 
 
 def test_parse_keywords():
-    kw = frontend.parse_keywords(['_', 'dgettext:2',
+    kw = frontend.parse_keywords(['_', '_:1,2', 'dgettext:2',
                                   'dngettext:2,3', 'pgettext:1c,2'])
     assert kw == {
-        '_': None,
-        'dgettext': (2,),
-        'dngettext': (2, 3),
-        'pgettext': ((1, 'c'), 2),
+        '_': [None, (1, 2)],
+        'dgettext': [(2,)],
+        'dngettext': [(2, 3)],
+        'pgettext': [((1, 'c'), 2)],
     }


### PR DESCRIPTION
[xgettext](https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/xgettext-Invocation.html#Language-specific-options) allows to have different arguments for same keyword, whereas babel doesn't. This pull request fix it.

Example
-----------
some_file.py contents:
```
print _("Hello")
print _("Event", "Events", 5)
```

- output of `xgettext some_file.py --language=Python --output-dir=locale --keyword=_ --keyword=_:1,2`:    
```
#: some_file.py:1
msgid "Hello"
msgstr ""

#: some_file.py:2
msgid "Event"
msgid_plural "Events"
msgstr[0] ""
msgstr[1] ""
```
- output of `pybabel extract ./ --output=locale/messages.pot --keyword=_ --keyword=_:1,2`    
```
#: some_file.py:1
msgid "Hello"
msgstr ""

#: some_file.py:2
msgid "Event"
msgstr ""
```

As we can see, xgettext correctly found plural argument list for `_("Event", "Events", 5)`. But babel treats function `_` to have only one argument, ignoring option `--keyword=_:1,2` and therefore assumes, that "Event" has no plural forms.

P.S.
In [tornado](http://www.tornadoweb.org/en/stable/locale.html?highlight=locale#module-tornado.locale) web framework, function `_` can take both the single string and a string with plural form and with count. I found it useful, as we don't need to have another translate function name for such case.