### PR TITLE
Last attempt to support parent locale exceptions

### DIFF
--- a/babel/localedata/__init__.py
+++ b/babel/localedata/__init__.py
@@ -81,11 +81,14 @@ def load(name, merge_inherited=True):
             if name == 'root' or not merge_inherited:
                 data = {}
             else:
-                parts = name.split('_')
-                if len(parts) == 1:
-                    parent = 'root'
-                else:
-                    parent = '_'.join(parts[:-1])
+                from babel.core import get_global
+                parent = get_global('parent_exceptions').get(name)
+                if not parent:
+                    parts = name.split('_')
+                    if len(parts) == 1:
+                        parent = 'root'
+                    else:
+                        parent = '_'.join(parts[:-1])
                 data = load(parent).copy()
             filename = os.path.join(_dirname, '%s.dat' % name)
             fileobj = open(filename, 'rb')

--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -258,7 +258,7 @@ def format_currency(number, currency, format=None, locale=LC_NUMERIC):
     >>> format_currency(1099.98, 'USD', locale='en_US')
     u'$1,099.98'
     >>> format_currency(1099.98, 'USD', locale='es_CO')
-    u'1.099,98\\xa0US$'
+    u'US$1.099,98'
     >>> format_currency(1099.98, 'EUR', locale='de_DE')
     u'1.099,98\\xa0\\u20ac'
 

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -145,6 +145,7 @@ def main():
         variant_aliases = global_data.setdefault('variant_aliases', {})
         likely_subtags = global_data.setdefault('likely_subtags', {})
         territory_currencies = global_data.setdefault('territory_currencies', {})
+        parent_exceptions = global_data.setdefault('parent_exceptions', {})
 
         # create auxiliary zone->territory map from the windows zones (we don't set
         # the 'zones_territories' map directly here, because there are some zones
@@ -222,6 +223,12 @@ def main():
                                               'tender', 'true') == 'true'))
             region_currencies.sort(key=_currency_sort_key)
             territory_currencies[region_code] = region_currencies
+
+        # Explicit parent locales
+        for paternity in sup.findall('.//parentLocales/parentLocale'):
+            parent = paternity.attrib['parent']
+            for child in paternity.attrib['locales'].split():
+                parent_exceptions[child] = parent
 
         outfile = open(global_path, 'wb')
         try:

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -243,7 +243,7 @@ def test_format_currency():
     assert (numbers.format_currency(1099.98, 'USD', locale='en_US')
             == u'$1,099.98')
     assert (numbers.format_currency(1099.98, 'USD', locale='es_CO')
-            == u'1.099,98\xa0US$')
+            == u'US$1.099,98')
     assert (numbers.format_currency(1099.98, 'EUR', locale='de_DE')
             == u'1.099,98\xa0\u20ac')
     assert (numbers.format_currency(1099.98, 'EUR', u'\xa4\xa4 #,##0.00',


### PR DESCRIPTION
The method to generate the name for the parent locale has some exceptions. Notably the latin america regions (es_MX, es_CO, es_AR, etc...) which should inherit from es_419 instead of es. Fortunately, these exceptions are described in the element of the supplemental data document.

This pull request tries to implement the proper locale inheritance for such cases.

~~There is an ugly hack because one of the commits introduces a circular dependency between `babel.core` and `babel.locale`.~~

**NOTE:** This is a new pull request that should supersede #117 and fix #97.
