### PR TITLE
travis: Submit coverage to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,15 @@ python:
 
 install:
   - pip install --upgrade pip
-  - pip install pytest
+  - pip install pytest pytest-cov
   - pip install --editable .
 
 # Use travis docker infrastructure for greater speed
 sudo: false
 
-script: make test
+script:
+  - make test-cov
+  - bash <(curl -s https://codecov.io/bash)
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 test: import-cldr
 	@PYTHONWARNINGS=default py.test
 
+test-cov: import-cldr
+	@PYTHONWARNINGS=default py.test --cov=babel
+
 test-env:
 	@virtualenv test-env
 	@test-env/bin/pip install pytest


### PR DESCRIPTION
This will make us able to monitor test coverage more closely to make babel more stable.

@mitsuhiko I can't activate codecov for this repository, you need to do that with the admin access. You should be able to log in at https://codecov.io/ and activate it for this repository, the scripts in this PR will do the rest. Takes 30 seconds.

@erickwilder as we agreed on we probably want to enforce a certain patch coverage or so. That needs to be discussed and @mitsuhiko needs to put it in the UI then which is easy.