### PR TITLE
gitignore: Add temporary editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*~
+*.swp
+.idea
 *.so
 docs/_build
 *.pyc


### PR DESCRIPTION
.idea stores settings for PyCharm, ~ files are temporary files e.g. used
by gedit. .swp is used by vim. We don't want any of those to be
accidentally committed in the repo.