### PR TITLE
Avoid incompatible *.dat files between Python 2 and 3

### DIFF
--- a/babel/numbers.py
+++ b/babel/numbers.py
@@ -135,6 +135,10 @@ def get_territory_currencies(territory, start_date=None, end_date=None,
 
     result = []
     for currency_code, start, end, is_tender in curs:
+        if start:
+            start = date_(*start)
+        if end:
+            end = date_(*end)
         if ((is_tender and tender) or \
             (not is_tender and non_tender)) and _is_active(start, end):
             if include_details:

--- a/scripts/import_cldr.py
+++ b/scripts/import_cldr.py
@@ -21,8 +21,6 @@ try:
 except ImportError:
     from xml.etree import ElementTree
 
-from datetime import date
-
 # Make sure we're using Babel source, and not some previously installed version
 sys.path.insert(0, os.path.join(os.path.dirname(sys.argv[0]), '..'))
 
@@ -103,12 +101,12 @@ def _parse_currency_date(s):
     if not s:
         return None
     parts = s.split('-', 2)
-    return date(*map(int, parts + [1] * (3 - len(parts))))
+    return tuple(map(int, parts + [1] * (3 - len(parts))))
 
 
 def _currency_sort_key(tup):
     code, start, end, tender = tup
-    return int(not tender), start or date(1, 1, 1)
+    return int(not tender), start or (1, 1, 1)
 
 
 def main():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -269,3 +269,29 @@ def test_parse_locale():
     assert core.parse_locale('en_US.UTF-8') == ('en', 'US', None, None)
     assert (core.parse_locale('de_DE.iso885915@euro') ==
             ('de', 'DE', None, None))
+
+def test_compatible_classes_in_global_and_localedata():
+    # Use pickle module rather than cPickle since cPickle.Unpickler is a method
+    # on Python 2
+    import pickle
+
+    class Unpickler(pickle.Unpickler):
+        def find_class(self, module, name):
+            # *.dat files must have compatible classes between Python 2 and 3
+            if module.split('.')[0] == 'babel':
+                return pickle.Unpickler.find_class(self, module, name)
+            raise pickle.UnpicklingError("global '%s.%s' is forbidden" %
+                                         (module, name))
+
+    def load(filename):
+        with open(filename, 'rb') as f:
+            return Unpickler(f).load()
+
+    load('babel/global.dat')
+    load('babel/localedata/root.dat')
+    load('babel/localedata/en.dat')
+    load('babel/localedata/en_US.dat')
+    load('babel/localedata/en_US_POSIX.dat')
+    load('babel/localedata/zh_Hans_CN.dat')
+    load('babel/localedata/zh_Hant_TW.dat')
+    load('babel/localedata/es_419.dat')


### PR DESCRIPTION
Proposed changes for #174.

In Babel 2.0, `*.dat` files use `datetime.date` class. However, pickle data format for the `date` class is incompatible between Python 2 and 3. Proposed changes remove uses of `date` class from `*.dat` files and add check for only `babel.*` classes in `*.dat` files.