### PR TITLE
Backport CI settings to 2.x

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -1,0 +1,45 @@
+# From https://github.com/ogrisel/python-appveyor-demo/blob/master/appveyor.yml
+
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\.ci\\run_with_env.cmd"
+
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python33-x64"
+      PYTHON_VERSION: "3.3.x"
+      PYTHON_ARCH: "64"
+
+branches:  # Only build official branches, PRs are built anyway.
+  only:
+    - master
+    - 2.x-maintenance
+    - /release.*/
+
+install:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  # Build data files
+  - "pip install . pytest"
+  - "python setup.py import_cldr"
+
+build: false  # Not a C# project, build stuff at the test step instead.
+
+test_script:
+  - "%CMD_IN_ENV% python -m pytest"

--- a/.ci/deploy.linux.sh
+++ b/.ci/deploy.linux.sh
@@ -1,0 +1,4 @@
+set -x
+set -e
+
+bash <(curl -s https://codecov.io/bash)

--- a/.ci/deploy.osx.sh
+++ b/.ci/deploy.osx.sh
@@ -1,0 +1,4 @@
+set -x
+set -e
+
+echo "Due to a bug in codecov, coverage cannot be deployed for Mac builds."

--- a/.ci/deps.linux.sh
+++ b/.ci/deps.linux.sh
@@ -1,0 +1,4 @@
+set -x
+set -e
+
+echo "No dependencies to install for linux."

--- a/.ci/deps.osx.sh
+++ b/.ci/deps.osx.sh
@@ -1,0 +1,11 @@
+set -e
+set -x
+
+# Install packages with brew
+brew update >/dev/null
+brew outdated pyenv || brew upgrade --quiet pyenv
+
+# Install required python version for this build
+pyenv install -ks $PYTHON_VERSION
+pyenv global $PYTHON_VERSION
+python --version

--- a/.ci/run_with_env.cmd
+++ b/.ci/run_with_env.cmd
@@ -1,0 +1,47 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds do not require specific environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+
+SET MAJOR_PYTHON_VERSION="%PYTHON_VERSION:~0,1%"
+IF %MAJOR_PYTHON_VERSION% == "2" (
+    SET WINDOWS_SDK_VERSION="v7.0"
+) ELSE IF %MAJOR_PYTHON_VERSION% == "3" (
+    SET WINDOWS_SDK_VERSION="v7.1"
+) ELSE (
+    ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+    EXIT 1
+)
+
+IF "%PYTHON_ARCH%"=="64" (
+    ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+    SET DISTUTILS_USE_SDK=1
+    SET MSSdk=1
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*~
+*.swp
+.idea
 *.so
 docs/_build
 *.pyc

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,0 +1,2 @@
+merge:
+  script: echo "Nothing to do (yet)."

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,15 @@ python:
 
 install:
   - pip install --upgrade pip
-  - pip install pytest
+  - pip install pytest pytest-cov
   - pip install --editable .
 
-script: make test
+# Use travis docker infrastructure for greater speed
+sudo: false
+
+script:
+  - make test-cov
+  - bash <(curl -s https://codecov.io/bash)
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 
 sudo: false
 
-cache: false
+cache:
+  directories:
+  - cldr
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,46 @@
 language: python
 
-python:
-  - "2.6"
-  - "2.7"
-  - "pypy"
-  - "3.3"
+sudo: false
+
+cache: false
+
+matrix:
+  include:
+    - os: linux
+      python: 2.6
+    - os: linux
+      python: 2.7
+    - os: linux
+      python: pypy
+    - os: linux
+      python: 3.3
+    - os: osx
+      language: generic
+      env:
+      - PYTHON_VERSION=2.6.6
+      - PYENV_ROOT=~/.pyenv
+      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
+    - os: osx
+      language: generic
+      env:
+      - PYTHON_VERSION=2.7.10
+      - PYENV_ROOT=~/.pyenv
+      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
+    - os: osx
+      language: generic
+      env:
+      - PYTHON_VERSION=pypy-2.6.0
+      - PYENV_ROOT=~/.pyenv
+      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
+    - os: osx
+      language: generic
+      env:
+      - PYTHON_VERSION=3.3.6
+      - PYENV_ROOT=~/.pyenv
+      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
 
 install:
+  - bash .ci/deps.${TRAVIS_OS_NAME}.sh
   - pip install --upgrade pip
   - pip install pytest pytest-cov
   - pip install --editable .
@@ -16,7 +50,7 @@ sudo: false
 
 script:
   - make test-cov
-  - bash <(curl -s https://codecov.io/bash)
+  - bash .ci/deploy.${TRAVIS_OS_NAME}.sh
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 test: import-cldr
-	@PYTHONWARNINGS=default py.test
+	@PYTHONWARNINGS=default python -m pytest
 
 test-cov: import-cldr
-	@PYTHONWARNINGS=default py.test --cov=babel
+	@PYTHONWARNINGS=default python -m pytest --cov=babel
 
 test-env:
 	@virtualenv test-env

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 test: import-cldr
 	@PYTHONWARNINGS=default py.test
 
+test-cov: import-cldr
+	@PYTHONWARNINGS=default py.test --cov=babel
+
 test-env:
 	@virtualenv test-env
 	@test-env/bin/pip install pytest


### PR DESCRIPTION
This pull request adds near the same CI settings found at the `master` branch. The only difference is that I removed any Python 3.4 related settings. Official 3.4 support was added (and I think it should remain) in the upcoming 3.0 release.