### PR TITLE
Improve odict performance by making key search O(1)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ Version 3.0
 
 - Upgraded data to CLDR 26
 - Add official support for Python 3.4
+- Improved odict performance which is used during localization file
+  build, should improve compilation time for large projects
 
 Version 2.0
 -----------

--- a/babel/util.py
+++ b/babel/util.py
@@ -172,8 +172,9 @@ class odict(dict):
         self._keys.remove(key)
 
     def __setitem__(self, key, item):
+        new_key = key not in self
         dict.__setitem__(self, key, item)
-        if key not in self._keys:
+        if new_key:
             self._keys.append(key)
 
     def __iter__(self):


### PR DESCRIPTION
Odict setitem method is linearly searching if item is present in keys list, which significantly reduces performance on big dict. Make it use hash.