### PR TITLE
Add format_timedelta(format='narrow') support

### DIFF
--- a/babel/dates.py
+++ b/babel/dates.py
@@ -739,6 +739,13 @@ def format_timedelta(delta, granularity='second', threshold=.85,
     >>> format_timedelta(timedelta(hours=-1), add_direction=True, locale='en')
     u'1 hour ago'
 
+    The format parameter controls how compact or wide the presentation is:
+
+    >>> format_timedelta(timedelta(hours=3), format='short', locale='en')
+    u'3 hrs'
+    >>> format_timedelta(timedelta(hours=3), format='narrow', locale='en')
+    u'3h'
+
     :param delta: a ``timedelta`` object representing the time difference to
                   format, or the delta in seconds as an `int` value
     :param granularity: determines the smallest unit that should be displayed,
@@ -751,13 +758,13 @@ def format_timedelta(delta, granularity='second', threshold=.85,
                           positive timedelta will include the information about
                           it being in the future, a negative will be information
                           about the value being in the past.
-    :param format: the format (currently only "long" and "short" are supported,
+    :param format: the format, can be "narrow", "short" or "long". (
                    "medium" is deprecated, currently converted to "long" to
                    maintain compatibility)
     :param locale: a `Locale` object or a locale identifier
     """
-    if format not in ('short', 'medium', 'long'):
-        raise TypeError('Format can only be one of "short" or "medium"')
+    if format not in ('narrow', 'short', 'medium', 'long'):
+        raise TypeError('Format must be one of "narrow", "short" or "long"')
     if format == 'medium':
         warnings.warn('"medium" value for format param of format_timedelta'
                       ' is deprecated. Use "long" instead',

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -310,6 +310,14 @@ class FormatTimedeltaTestCase(unittest.TestCase):
                                         add_direction=True)
         self.assertEqual('1 hour ago', string)
 
+    def test_format_narrow(self):
+        string = dates.format_timedelta(timedelta(hours=1),
+                                        locale='en', format='narrow')
+        self.assertEqual('1h', string)
+        string = dates.format_timedelta(timedelta(hours=-2),
+                                        locale='en', format='narrow')
+        self.assertEqual('2h', string)
+
 
 class TimeZoneAdjustTestCase(unittest.TestCase):
     def _utc(self):

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -318,6 +318,14 @@ class FormatTimedeltaTestCase(unittest.TestCase):
                                         locale='en', format='narrow')
         self.assertEqual('2h', string)
 
+    def test_format_invalid(self):
+        self.assertRaises(TypeError, dates.format_timedelta,
+                          timedelta(hours=1), format='')
+        self.assertRaises(TypeError, dates.format_timedelta,
+                          timedelta(hours=1), format='bold italic')
+        self.assertRaises(TypeError, dates.format_timedelta,
+                          timedelta(hours=1), format=None)
+
 
 class TimeZoneAdjustTestCase(unittest.TestCase):
     def _utc(self):


### PR DESCRIPTION
e.g.
```python
>>> format_timedelta(timedelta(hours=3), format='short', locale='en')
u'3 hrs'
>>> format_timedelta(timedelta(hours=3), format='narrow', locale='en')
u'3h'
>>> print format_timedelta(timedelta(hours=3), format='short', locale='gu_IN')
3 કલાક
>>> print format_timedelta(timedelta(hours=3), format='narrow', locale='gu_IN')
3 ક
```