### PR TITLE
CHANGES: Add "narrow" support for format_timedelta

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Version 3.0
 - Add official support for Python 3.4
 - Improved odict performance which is used during localization file
   build, should improve compilation time for large projects
+- Add support for "narrow" format for format_timedelta
 
 Version 2.0
 -----------


### PR DESCRIPTION
This was introduced in
https://github.com/moreati/babel/commit/edc5eb57b2f7c36bb419be4d23396746d233767b
and forgotten to add to CHANGES.